### PR TITLE
Refactor/translations (#9)

### DIFF
--- a/app/src/main/java/net/dom53/inkita/ui/download/DownloadQueueScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/download/DownloadQueueScreen.kt
@@ -25,7 +25,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import net.dom53.inkita.R
 import net.dom53.inkita.data.local.db.entity.DownloadTaskEntity
 import net.dom53.inkita.data.local.db.entity.DownloadedPageEntity
 import java.io.File
@@ -73,19 +75,22 @@ fun DownloadQueueScreen(viewModel: DownloadQueueViewModel) {
         }
 
     Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text("Downloads", style = MaterialTheme.typography.headlineSmall)
+        Text(stringResource(R.string.download_screen_title), style = MaterialTheme.typography.headlineSmall)
         TabRow(selectedTabIndex = selectedTab) {
             Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 }) {
-                Text("Queue", modifier = Modifier.padding(12.dp))
+                Text(stringResource(R.string.general_queue), modifier = Modifier.padding(12.dp))
             }
             Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 }) {
-                Text("Completed", modifier = Modifier.padding(12.dp))
+                Text(stringResource(R.string.general_completed), modifier = Modifier.padding(12.dp))
             }
             Tab(selected = selectedTab == 2, onClick = { selectedTab = 2 }) {
-                Text("Downloaded", modifier = Modifier.padding(12.dp))
+                Text(stringResource(R.string.general_downloaded), modifier = Modifier.padding(12.dp))
             }
         }
         when (selectedTab) {
@@ -125,7 +130,7 @@ fun DownloadQueueScreen(viewModel: DownloadQueueViewModel) {
                         horizontalArrangement = Arrangement.End,
                     ) {
                         Button(onClick = { viewModel.clearCompleted() }) {
-                            Text("Clear completed")
+                            Text(stringResource(R.string.download_clear_completed))
                         }
                     }
                 }
@@ -160,32 +165,67 @@ private fun TaskRow(
 ) {
     val labelType =
         when (task.type) {
-            DownloadTaskEntity.TYPE_PAGES -> "Pages"
-            DownloadTaskEntity.TYPE_VOLUME -> "Volume"
-            DownloadTaskEntity.TYPE_SERIES -> "Series"
+            DownloadTaskEntity.TYPE_PAGES -> stringResource(R.string.general_pages)
+            DownloadTaskEntity.TYPE_VOLUME -> stringResource(R.string.download_type_volume)
+            DownloadTaskEntity.TYPE_SERIES -> stringResource(R.string.general_series)
             else -> task.type
         }
     Column(
         modifier = Modifier.fillMaxWidth().padding(8.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        Text("Series ${task.seriesId} · $labelType", style = MaterialTheme.typography.bodyLarge)
-        Text("Chapter ${task.chapterId ?: "-"} pages ${task.pageStart ?: "-"}..${task.pageEnd ?: "-"}")
-        Text("State: ${task.state}")
+        Text(
+            stringResource(R.string.download_item_title, task.seriesId, labelType),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Text(
+            stringResource(
+                R.string.download_item_chapter_pages,
+                task.chapterId ?: "-",
+                task.pageStart ?: "-",
+                task.pageEnd ?: "-",
+            ),
+        )
+        Text(stringResource(R.string.download_item_state, task.state))
         Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            Text("Created: ${formatDate(task.createdAt)}", style = MaterialTheme.typography.bodySmall)
-            Text("Updated: ${formatDate(task.updatedAt)}", style = MaterialTheme.typography.bodySmall)
+            if (task.createdAt > 0) {
+                Text(
+                    stringResource(R.string.download_item_created, formatDate(task.createdAt)),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            if (task.updatedAt > 0) {
+                Text(
+                    stringResource(R.string.download_item_updated, formatDate(task.updatedAt)),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
         }
         if (task.total > 0) {
             val pct = (task.progress * 100f / task.total).toInt().coerceIn(0, 100)
-            Text("Progress: ${task.progress}/${task.total} ($pct%)", style = MaterialTheme.typography.bodySmall)
+            Text(
+                stringResource(R.string.download_item_progress, task.progress, task.total, pct),
+                style = MaterialTheme.typography.bodySmall,
+            )
         }
         if (task.bytesTotal > 0) {
             val pct = (task.bytes * 100f / task.bytesTotal).toInt().coerceIn(0, 100)
-            Text("Bytes: ${formatBytes(task.bytes)} / ${formatBytes(task.bytesTotal)} ($pct%)", style = MaterialTheme.typography.bodySmall)
+            Text(
+                stringResource(
+                    R.string.download_item_bytes,
+                    formatBytes(task.bytes),
+                    formatBytes(task.bytesTotal),
+                    pct,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+            )
         }
         task.error?.takeIf { it.isNotBlank() }?.let { err ->
-            Text("Error: $err", color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            Text(
+                stringResource(R.string.download_item_error, err),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+            )
         }
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -197,28 +237,28 @@ private fun TaskRow(
                 DownloadTaskEntity.STATE_RUNNING,
                 -> {
                     Button(onClick = onPause) {
-                        Text("Pause")
+                        Text(stringResource(R.string.download_action_pause))
                     }
                     Button(onClick = onCancel, modifier = Modifier.padding(start = 8.dp)) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.general_cancel))
                     }
                 }
                 DownloadTaskEntity.STATE_PAUSED -> {
                     Button(onClick = onResume) {
-                        Text("Resume")
+                        Text(stringResource(R.string.download_action_resume))
                     }
                 }
                 DownloadTaskEntity.STATE_FAILED -> {
                     Button(onClick = onRetry) {
-                        Text("Retry")
+                        Text(stringResource(R.string.download_action_retry))
                     }
                     Button(onClick = onCancel, modifier = Modifier.padding(start = 8.dp)) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.general_cancel))
                     }
                 }
                 DownloadTaskEntity.STATE_CANCELED -> {
                     Button(onClick = onClear) {
-                        Text("Clear")
+                        Text(stringResource(R.string.download_action_clear))
                     }
                 }
                 else -> Unit
@@ -238,13 +278,18 @@ private fun DownloadedRow(
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         Text(
-            "Series ${page.seriesId} · Chapter ${page.chapterId} · Page ${page.page}",
+            stringResource(
+                R.string.download_completed_title,
+                page.seriesId,
+                page.chapterId,
+                page.page,
+            ),
             style = MaterialTheme.typography.bodyLarge,
         )
-        Text("Status: ${page.status}")
+        Text(stringResource(R.string.download_completed_status, page.status))
         Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            Text("Updated: ${formatDate(page.updatedAt)}", style = MaterialTheme.typography.bodySmall)
-            Text("Size: ${formatBytes(page.sizeBytes)}", style = MaterialTheme.typography.bodySmall)
+            Text(stringResource(R.string.download_completed_updated, formatDate(page.updatedAt)), style = MaterialTheme.typography.bodySmall)
+            Text(stringResource(R.string.download_completed_size, formatBytes(page.sizeBytes)), style = MaterialTheme.typography.bodySmall)
         }
         Text(page.htmlPath, style = MaterialTheme.typography.bodySmall)
         Row(
@@ -253,10 +298,10 @@ private fun DownloadedRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Button(onClick = onOpen) {
-                Text("Open")
+                Text(stringResource(R.string.download_completed_open))
             }
             Button(onClick = onDelete, modifier = Modifier.padding(start = 8.dp)) {
-                Text("Delete")
+                Text(stringResource(R.string.download_completed_delete))
             }
         }
     }

--- a/app/src/main/java/net/dom53/inkita/ui/history/HistoryScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/history/HistoryScreen.kt
@@ -88,7 +88,7 @@ fun HistoryScreen(appPreferences: AppPreferences) {
                 if (resp.isSuccessful) {
                     history.value = resp.body().orEmpty()
                 } else {
-                    error.value = "HTTP ${resp.code()}"
+                    error.value = context.getString(R.string.history_error_http, resp.code())
                 }
             }.onFailure { e -> error.value = e.message }
         isLoading.value = false
@@ -220,7 +220,7 @@ private fun HistoryRow(
             ) {
                 when (painter.state) {
                     is AsyncImagePainter.State.Loading -> CircularProgressIndicator(modifier = Modifier.size(18.dp))
-                    is AsyncImagePainter.State.Error -> Text("No cover", style = MaterialTheme.typography.labelSmall)
+                    is AsyncImagePainter.State.Error -> Text(stringResource(R.string.history_no_cover), style = MaterialTheme.typography.labelSmall)
                     else -> SubcomposeAsyncImageContent()
                 }
             }
@@ -238,8 +238,12 @@ private fun HistoryRow(
             val chapterRange =
                 when {
                     item.chapterStart != null && item.chapterEnd != null && item.chapterStart != item.chapterEnd ->
-                        "Ch. ${chapterLabel(item.chapterStart)}–${chapterLabel(item.chapterEnd)}"
-                    item.chapterEnd != null -> "Ch. ${chapterLabel(item.chapterEnd)}"
+                        stringResource(
+                            R.string.history_chapter_range,
+                            chapterLabel(item.chapterStart),
+                            chapterLabel(item.chapterEnd),
+                        )
+                    item.chapterEnd != null -> stringResource(R.string.history_chapter_single, chapterLabel(item.chapterEnd))
                     else -> null
                 }
             chapterRange?.let {
@@ -249,7 +253,7 @@ private fun HistoryRow(
             if (timeRange != null) {
                 Text(timeRange, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
-            Text("Entries: ${item.count}", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(stringResource(R.string.history_entries_count, item.count), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }

--- a/app/src/main/java/net/dom53/inkita/ui/seriesdetail/SeriesDetailScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/seriesdetail/SeriesDetailScreen.kt
@@ -314,28 +314,28 @@ fun SeriesDetailScreen(
                                 }
                                 DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
                                     DropdownMenuItem(
-                                        text = { Text("Download all") },
+                                        text = { Text(stringResource(R.string.series_download_all)) },
                                         onClick = {
                                             menuOpen = false
                                             viewModel.downloadAllVolumes()
                                         },
                                     )
                                     DropdownMenuItem(
-                                        text = { Text("Download missing") },
+                                        text = { Text(stringResource(R.string.series_download_missing)) },
                                         onClick = {
                                             menuOpen = false
                                             viewModel.downloadMissingVolumes()
                                         },
                                     )
                                     DropdownMenuItem(
-                                        text = { Text("Clear downloads") },
+                                        text = { Text(stringResource(R.string.series_clear_downloads)) },
                                         onClick = {
                                             menuOpen = false
                                             viewModel.clearDownloads()
                                         },
                                     )
                                     DropdownMenuItem(
-                                        text = { Text("Download queue") },
+                                        text = { Text(stringResource(R.string.series_open_download_queue)) },
                                         onClick = {
                                             menuOpen = false
                                             onOpenDownloads?.invoke()

--- a/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsAdvancedScreen.kt
@@ -575,7 +575,7 @@ fun SettingsAdvancedScreen(
                             selected = clearTarget == ClearTarget.Thumbnails,
                         ) { clearTarget = ClearTarget.Thumbnails }
                         ClearOptionRow(
-                            label = "Downloaded pages",
+                            label = stringResource(R.string.advanced_cache_clear_downloaded_pages),
                             selected = clearTarget == ClearTarget.DownloadedPages,
                         ) { clearTarget = ClearTarget.DownloadedPages }
                     }
@@ -623,16 +623,16 @@ fun SettingsAdvancedScreen(
                     val stats = cacheManager.getCacheStats()
                     val body =
                         buildString {
-                            appendLine("Series: ${stats.seriesCount}")
-                            appendLine("Tab refs: ${stats.tabRefs}")
-                            appendLine("Browse refs: ${stats.browseRefs}")
-                            appendLine("Details: ${stats.detailsCount}")
-                            appendLine("Volumes: ${stats.volumesCount}")
-                            appendLine("Chapters: ${stats.chaptersCount}")
-                            appendLine("DB size: ${bytesToMb(stats.dbBytes)}")
-                            appendLine("Thumbnails: ${bytesToMb(stats.thumbnailsBytes)}")
-                            appendLine("Last library refresh: ${formatTs(stats.lastLibraryRefresh)}")
-                            appendLine("Last browse refresh: ${formatTs(stats.lastBrowseRefresh)}")
+                            appendLine(context.getString(R.string.advanced_cache_stats_series, stats.seriesCount))
+                            appendLine(context.getString(R.string.advanced_cache_stats_tabs, stats.tabRefs))
+                            appendLine(context.getString(R.string.advanced_cache_stats_browse, stats.browseRefs))
+                            appendLine(context.getString(R.string.advanced_cache_stats_details, stats.detailsCount))
+                            appendLine(context.getString(R.string.advanced_cache_stats_volumes, stats.volumesCount))
+                            appendLine(context.getString(R.string.advanced_cache_stats_chapters, stats.chaptersCount))
+                            appendLine(context.getString(R.string.advanced_cache_stats_db_size, bytesToMb(stats.dbBytes)))
+                            appendLine(context.getString(R.string.advanced_cache_stats_thumbnails, bytesToMb(stats.thumbnailsBytes)))
+                            appendLine(context.getString(R.string.advanced_cache_stats_last_library, formatTs(stats.lastLibraryRefresh)))
+                            appendLine(context.getString(R.string.advanced_cache_stats_last_browse, formatTs(stats.lastBrowseRefresh)))
                         }
                     statsDialog = body
                 }

--- a/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsAppearanceScreen.kt
@@ -52,9 +52,9 @@ fun SettingsAppearanceScreen(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         IconButton(onClick = onBack) {
-            Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+            Icon(Icons.Filled.ArrowBack, contentDescription = stringResource(R.string.general_back))
         }
-        Text("Appearance", style = MaterialTheme.typography.headlineSmall)
+        Text(stringResource(R.string.settings_appearance_title), style = MaterialTheme.typography.headlineSmall)
 
         ThemeOptionRow(
             label = stringResource(R.string.settings_appearance_by_system),

--- a/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsDownloadScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsDownloadScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
@@ -103,14 +104,14 @@ fun SettingsDownloadScreen(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             IconButton(onClick = onBack) {
-                Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                Icon(Icons.Filled.ArrowBack, contentDescription = stringResource(net.dom53.inkita.R.string.general_back))
             }
-            Text("Downloads", style = MaterialTheme.typography.titleLarge)
+            Text(stringResource(net.dom53.inkita.R.string.settings_downloads_title), style = MaterialTheme.typography.titleLarge)
         }
 
         SettingToggleRow(
-            title = "Allow metered data",
-            subtitle = "Permit downloads on mobile data. When off, downloads require Wi‑Fi.",
+            title = stringResource(net.dom53.inkita.R.string.settings_downloads_allow_metered_title),
+            subtitle = stringResource(net.dom53.inkita.R.string.settings_downloads_allow_metered_subtitle),
             checked = allowMetered,
             onCheckedChange = {
                 allowMetered = it
@@ -119,8 +120,8 @@ fun SettingsDownloadScreen(
         )
 
         SettingToggleRow(
-            title = "Allow when battery is low",
-            subtitle = "When off, downloads wait until battery is not low.",
+            title = stringResource(net.dom53.inkita.R.string.settings_downloads_allow_low_battery_title),
+            subtitle = stringResource(net.dom53.inkita.R.string.settings_downloads_allow_low_battery_subtitle),
             checked = allowLowBattery,
             onCheckedChange = {
                 allowLowBattery = it
@@ -129,8 +130,8 @@ fun SettingsDownloadScreen(
         )
 
         SettingToggleRow(
-            title = "Prefer offline pages",
-            subtitle = "When available, reader will use downloaded pages even when online.",
+            title = stringResource(net.dom53.inkita.R.string.settings_downloads_prefer_offline_title),
+            subtitle = stringResource(net.dom53.inkita.R.string.settings_downloads_prefer_offline_subtitle),
             checked = preferOffline,
             onCheckedChange = {
                 preferOffline = it
@@ -139,11 +140,11 @@ fun SettingsDownloadScreen(
         )
 
         Divider(modifier = Modifier.padding(vertical = 8.dp))
-        Text("Delete after reading", style = MaterialTheme.typography.titleMedium)
+        Text(stringResource(net.dom53.inkita.R.string.settings_downloads_delete_after_section), style = MaterialTheme.typography.titleMedium)
 
         SettingToggleRow(
-            title = "Delete when marked as read",
-            subtitle = "Automatically remove downloads after you mark items as read.",
+            title = stringResource(net.dom53.inkita.R.string.settings_downloads_delete_after_mark_title),
+            subtitle = stringResource(net.dom53.inkita.R.string.settings_downloads_delete_after_mark_subtitle),
             checked = deleteAfterMarkRead,
             onCheckedChange = {
                 deleteAfterMarkRead = it
@@ -152,8 +153,8 @@ fun SettingsDownloadScreen(
         )
 
         SelectionRow(
-            title = "Keep recent downloaded pages",
-            subtitle = "How many recently read downloaded pages stay on device before older ones are removed.",
+            title = stringResource(net.dom53.inkita.R.string.settings_downloads_keep_recent_title),
+            subtitle = stringResource(net.dom53.inkita.R.string.settings_downloads_keep_recent_subtitle),
             options = deleteAfterOptions(),
             selected = deleteAfterReadDepth,
             onSelect = { next ->
@@ -165,8 +166,8 @@ fun SettingsDownloadScreen(
         Divider(modifier = Modifier.padding(vertical = 8.dp))
 
         SettingToggleRow(
-            title = "Automatic retries",
-            subtitle = "Retry failed downloads automatically.",
+            title = stringResource(net.dom53.inkita.R.string.settings_downloads_auto_retry_title),
+            subtitle = stringResource(net.dom53.inkita.R.string.settings_downloads_auto_retry_subtitle),
             checked = retryEnabled,
             onCheckedChange = {
                 retryEnabled = it
@@ -176,8 +177,8 @@ fun SettingsDownloadScreen(
 
         if (retryEnabled) {
             NumberStepperRow(
-                title = "Max retry attempts",
-                subtitle = "Total attempts per task before it fails.",
+                title = stringResource(net.dom53.inkita.R.string.settings_downloads_max_retry_title),
+                subtitle = stringResource(net.dom53.inkita.R.string.settings_downloads_max_retry_subtitle),
                 value = maxRetries,
                 range = 1..5,
                 onChange = { next ->
@@ -199,22 +200,22 @@ fun SettingsDownloadScreen(
 
         Spacer(Modifier.height(8.dp))
         Text(
-            "These limits are applied to download and prefetch workers.",
+            stringResource(net.dom53.inkita.R.string.settings_downloads_limits_note),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
         Divider(modifier = Modifier.padding(vertical = 8.dp))
         Button(onClick = { showClearDialog = true }) {
-            Text("Clear downloaded pages")
+            Text(stringResource(net.dom53.inkita.R.string.settings_downloads_clear_downloaded))
         }
     }
 
     if (showClearDialog) {
         AlertDialog(
             onDismissRequest = { showClearDialog = false },
-            title = { Text("Clear downloaded pages") },
-            text = { Text("Remove all downloaded HTML pages and assets from device storage?") },
+            title = { Text(stringResource(net.dom53.inkita.R.string.settings_downloads_clear_downloaded_confirm_title)) },
+            text = { Text(stringResource(net.dom53.inkita.R.string.settings_downloads_clear_downloaded_confirm_text)) },
             confirmButton = {
                 Button(
                     onClick = {
@@ -223,16 +224,16 @@ fun SettingsDownloadScreen(
                             withContext(Dispatchers.IO) {
                                 downloadRepo.clearAllDownloads()
                             }
-                            Toast.makeText(context, "Downloaded pages cleared", Toast.LENGTH_SHORT).show()
+                            Toast.makeText(context, context.getString(net.dom53.inkita.R.string.settings_downloads_clear_downloaded_toast), Toast.LENGTH_SHORT).show()
                         }
                     },
                 ) {
-                    Text("Clear")
+                    Text(stringResource(net.dom53.inkita.R.string.settings_downloads_clear))
                 }
             },
             dismissButton = {
                 Button(onClick = { showClearDialog = false }) {
-                    Text("Cancel")
+                    Text(stringResource(net.dom53.inkita.R.string.general_cancel))
                 }
             },
         )
@@ -282,9 +283,9 @@ private fun ConcurrentRow(
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            Text("Max concurrent downloads", style = MaterialTheme.typography.bodyLarge)
+            Text(stringResource(net.dom53.inkita.R.string.settings_downloads_max_concurrent_title), style = MaterialTheme.typography.bodyLarge)
             Text(
-                "Limit how many page downloads run in parallel (1-6).",
+                stringResource(net.dom53.inkita.R.string.settings_downloads_max_concurrent_subtitle),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsGeneralScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsGeneralScreen.kt
@@ -125,9 +125,9 @@ fun SettingsGeneralScreen(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Column(modifier = Modifier.weight(1f).padding(end = 12.dp)) {
-                Text("Offline mode", style = MaterialTheme.typography.titleMedium)
+                Text(stringResource(R.string.settings_general_offline_mode_title), style = MaterialTheme.typography.titleMedium)
                 Text(
-                    "Force the app to behave as offline (skip network calls/work) even if connectivity is available.",
+                    stringResource(R.string.settings_general_offline_mode_subtitle),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsKavitaScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsKavitaScreen.kt
@@ -230,10 +230,10 @@ fun SettingsKavitaScreen(
                             serverUrl = host
                             apiKeyInput = ""
                             isEditingApiKey = false
-                            snackbarHostState.showSnackbar("Configuration saved. Please restart the app.")
+                            snackbarHostState.showSnackbar(context.getString(R.string.settings_kavita_saved_toast))
                         } catch (e: Exception) {
                             snackbarHostState.showSnackbar(
-                                "Save failed: ${e.message ?: "unknown error"}",
+                                context.getString(R.string.settings_kavita_save_failed, e.message ?: "unknown error"),
                             )
                         }
                     }
@@ -273,11 +273,13 @@ fun SettingsKavitaScreen(
                                     isEditingApiKey = false
                                     showHttpWarning = false
                                     warningFromSave = false
-                                    snackbarHostState.showSnackbar("Configuration saved. Please restart the app.")
+                                    snackbarHostState.showSnackbar(context.getString(R.string.settings_kavita_saved_toast))
                                 } catch (e: Exception) {
                                     showHttpWarning = false
                                     warningFromSave = false
-                                    snackbarHostState.showSnackbar("Save failed: ${e.message ?: "unknown error"}")
+                                    snackbarHostState.showSnackbar(
+                                        context.getString(R.string.settings_kavita_save_failed, e.message ?: context.getString(R.string.general_unknown_error)),
+                                    )
                                 }
                             } else {
                                 useHttps = false
@@ -297,7 +299,7 @@ fun SettingsKavitaScreen(
                         warningFromSave = false
                     },
                 ) {
-                    Text(stringResource(R.string.settings_kavita_http_warning_cancel))
+                    Text(stringResource(R.string.general_cancel))
                 }
             },
         )

--- a/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsPlaceholderScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsPlaceholderScreen.kt
@@ -29,7 +29,7 @@ fun SettingsPlaceholderScreen(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         IconButton(onClick = onBack) {
-            Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+            Icon(Icons.Filled.ArrowBack, contentDescription = stringResource(R.string.general_back))
         }
         Text(stringResource(titleRes), style = MaterialTheme.typography.headlineSmall)
         Text(stringResource(R.string.will_be_implemented), style = MaterialTheme.typography.bodyMedium)

--- a/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsStatsScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsStatsScreen.kt
@@ -163,7 +163,7 @@ fun SettingsStatsScreen(
 
         if (pagesPerYear.value.isNotEmpty()) {
             val max = (pagesPerYear.value.maxOfOrNull { it.count ?: 0 } ?: 1L).toInt()
-            item { Text(stringResource(R.string.stats_pages_per_yer), style = MaterialTheme.typography.titleMedium) }
+            item { Text(stringResource(R.string.stats_pages_per_year), style = MaterialTheme.typography.titleMedium) }
             items(pagesPerYear.value) { item ->
                 BarRow(
                     label = item.value?.toString() ?: "",
@@ -175,7 +175,7 @@ fun SettingsStatsScreen(
 
         if (wordsPerYear.value.isNotEmpty()) {
             val max = (wordsPerYear.value.maxOfOrNull { it.count ?: 0 } ?: 1L).toInt()
-            item { Text(stringResource(R.string.stats_words_per_yer), style = MaterialTheme.typography.titleMedium) }
+            item { Text(stringResource(R.string.stats_words_per_year), style = MaterialTheme.typography.titleMedium) }
             items(wordsPerYear.value) { item ->
                 BarRow(
                     label = item.value?.toString() ?: "",

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -14,8 +14,6 @@
     <string name="general_reading_status_completed">Dokončeno</string>
     <string name="general_reading_status_in_progress">Rozčteno</string>
     <string name="general_reading_status_unread">Nepřečteno</string>
-    <string name="general_username">Uživatelské jméno</string>
-    <string name="general_password">Heslo</string>
     <string name="general_option_soon">Možnosti vzhledu brzy přibudou</string>
     <string name="general_nav_option_soon">Možnosti navigace brzy přibudou</string>
     <string name="general_decrease">Snížit</string>
@@ -102,8 +100,6 @@
     <string name="general_weekly">Týdně</string>
     <!-- Languages -->
     <string name="general_language_system">Systém</string>
-    <string name="general_language_english">Angličtina</string>
-    <string name="general_language_czech">Čeština</string>
     <string name="general_language_label">Jazyk</string>
     <string name="general_language_en">Angličtina</string>
     <string name="general_language_cs">Čeština</string>
@@ -250,7 +246,6 @@
     <string name="settings_kavita_http_warning_title">Použít HTTP?</string>
     <string name="settings_kavita_http_warning_body">HTTP není šifrované. Používejte ho jen v důvěryhodné lokální síti. Pokračovat?</string>
     <string name="settings_kavita_http_warning_confirm">Pokračovat s HTTP</string>
-    <string name="settings_kavita_http_warning_cancel">Zrušit</string>
     <!--  About Inkita  -->
     <string name="settings_about_osl">Licence s otevřeným zdrojem</string>
     <string name="settings_about_osl_3rd">Knihovny třetích stran</string>
@@ -282,18 +277,13 @@
     <string name="stats_failed_stat_load">Nepodařilo se načíst statistiky.</string>
     <string name="stats_reading_sum">Souhrn čtení</string>
     <string name="stats_activity_last_30d">Aktivita (posledních 30 dní)</string>
-    <string name="stats_pages_per_yer">Stránky za rok</string>
-    <string name="stats_words_per_yer">Slova za rok</string>
-    <string name="stats_source_kavita_api_description">
-        Data pocházejí z endpointu /api/Stats služby Kavita. Lze je rozšířit o další grafy (den v týdnu, formáty, typy publikací atd.).
-    </string>
+    <string name="stats_pages_per_year">Stránky za rok</string>
+    <string name="stats_words_per_year">Slova za rok</string>
     <!-- Updates -->
     <string name="update_notification_title">Je dostupná aktualizace: %1$s</string>
     <string name="update_notification_text">Klepnutím stáhneš nejnovější verzi.</string>
     <string name="update_checking_title">Kontroluji aktualizace…</string>
     <string name="update_checking_text">Hledám novější verzi Inkita.</string>
-    <string name="update_up_to_date_title">Inkita je aktuální</string>
-    <string name="update_up_to_date_text">Nenašla se novější verze.</string>
     <string name="notifications_prompt_title">Povolit oznámení</string>
     <string name="notifications_prompt_body">Povol prosím oznámení, abychom tě mohli informovat o aktualizacích a stahování.</string>
     <string name="notifications_prompt_accept">Povolit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,8 +15,6 @@
     <string name="general_reading_status_completed">Completed</string>
     <string name="general_reading_status_in_progress">In progress</string>
     <string name="general_reading_status_unread">Unread</string>
-    <string name="general_username">Username</string>
-    <string name="general_password">Password</string>
     <string name="general_option_soon">Theme options coming soon</string>
     <string name="general_nav_option_soon">Navigation options coming soon</string>
     <string name="general_decrease">Decrease</string>
@@ -96,10 +94,11 @@
     <string name="general_words">Words</string>
     <string name="general_time">Time</string>
     <string name="general_weekly">Weekly</string>
+    <string name="general_queue">Queue</string>
+    <string name="general_downloaded">Downloaded</string>
+    <string name="general_unknown_error">unknown error</string>
     <!-- Languages -->
     <string name="general_language_system">System</string>
-    <string name="general_language_english">English</string>
-    <string name="general_language_czech">Czech</string>
     <string name="general_language_label">Language</string>
     <string name="general_language_en">English</string>
     <string name="general_language_cs">Czech</string>
@@ -246,6 +245,8 @@
     <string name="settings_kavita_http_warning_body">HTTP is unencrypted. Use it only on trusted local networks. Continue anyway?</string>
     <string name="settings_kavita_http_warning_confirm">Continue with HTTP</string>
     <string name="settings_kavita_http_warning_cancel">Cancel</string>
+    <string name="settings_kavita_saved_toast">Configuration saved. Please restart the app.</string>
+    <string name="settings_kavita_save_failed">Save failed: %1$s</string>
     <!-- About Inkita  -->
     <string name="settings_about_version">Version</string>
     <string name="settings_about_build_time">Build time</string>
@@ -277,18 +278,95 @@
     <string name="stats_failed_stat_load">Failed to load statistics.</string>
     <string name="stats_reading_sum">Reading summary</string>
     <string name="stats_activity_last_30d">Activity (last 30 days)</string>
-    <string name="stats_pages_per_yer">Pages per year</string>
-    <string name="stats_words_per_yer">Words per year</string>
-    <string name="stats_source_kavita_api_description">Data comes from Kavita’s /api/Stats endpoint. Can be expanded with additional charts (day of week, formats, publication types, etc.).</string>
+    <string name="stats_pages_per_year">Pages per year</string>
+    <string name="stats_words_per_year">Words per year</string>
     <!-- Update -->
     <string name="update_notification_title">Update available: %1$s</string>
     <string name="update_notification_text">Tap to download the latest version.</string>
     <string name="update_checking_title">Checking for updates…</string>
     <string name="update_checking_text">Looking for a newer Inkita build.</string>
-    <string name="update_up_to_date_title">Inkita is up to date</string>
-    <string name="update_up_to_date_text">No newer version found.</string>
     <string name="notifications_prompt_title">Enable notifications</string>
     <string name="notifications_prompt_body">Please allow notifications so we can alert you about updates and downloads.</string>
     <string name="notifications_prompt_accept">Enable</string>
     <string name="notifications_prompt_dismiss">Not now</string>
+    <!-- Series detail actions -->
+    <string name="series_download_all">Download all</string>
+    <string name="series_download_missing">Download missing</string>
+    <string name="series_clear_downloads">Clear downloads</string>
+    <string name="series_open_download_queue">Download queue</string>
+    <!-- Advanced settings -->
+    <string name="advanced_clear_cache">Clear cache</string>
+    <string name="advanced_downloaded_pages">Downloaded pages</string>
+    <string name="advanced_cache_stats_series">Series: %1$d</string>
+    <string name="advanced_cache_stats_tabs">Tab refs: %1$d</string>
+    <string name="advanced_cache_stats_browse">Browse refs: %1$d</string>
+    <string name="advanced_cache_stats_details">Details: %1$d</string>
+    <string name="advanced_cache_stats_volumes">Volumes: %1$d</string>
+    <string name="advanced_cache_stats_chapters">Chapters: %1$d</string>
+    <string name="advanced_cache_stats_db_size">DB size: %1$s</string>
+    <string name="advanced_cache_stats_thumbnails">Thumbnails: %1$s</string>
+    <string name="advanced_cache_stats_last_library">Last library refresh: %1$s</string>
+    <string name="advanced_cache_stats_last_browse">Last browse refresh: %1$s</string>
+    <string name="advanced_cache_clear_downloaded_pages">Downloaded pages</string>
+    <!-- Appearance settings -->
+    <string name="settings_appearance_title">Appearance</string>
+    <!-- Downloads queue -->
+    <string name="download_screen_title">Downloads</string>
+    <string name="download_clear_completed">Clear completed</string>
+    <string name="download_type_volume">Volume</string>
+    <string name="download_item_title">Series %1$s · %2$s</string>
+    <string name="download_item_chapter_pages">Chapter %1$s pages %2$s..%3$s</string>
+    <string name="download_item_state">State: %1$s</string>
+    <string name="download_item_created">Created: %1$s</string>
+    <string name="download_item_updated">Updated: %1$s</string>
+    <string name="download_item_progress">Progress: %1$d/%2$d (%3$d%%)</string>
+    <string name="download_item_bytes">Bytes: %1$s / %2$s (%3$d%%)</string>
+    <string name="download_item_error">Error: %1$s</string>
+    <string name="download_action_pause">Pause</string>
+    <string name="download_action_resume">Resume</string>
+    <string name="download_action_retry">Retry</string>
+    <string name="download_action_clear">Clear</string>
+    <string name="download_completed_title">Series %1$s · Chapter %2$s · Page %3$s</string>
+    <string name="download_completed_status">Status: %1$s</string>
+    <string name="download_completed_updated">Updated: %1$s</string>
+    <string name="download_completed_size">Size: %1$s</string>
+    <string name="download_completed_open">Open</string>
+    <string name="download_completed_delete">Delete</string>
+    <!-- Download settings -->
+    <string name="settings_downloads_title">Downloads</string>
+    <string name="settings_downloads_allow_metered_title">Allow metered data</string>
+    <string name="settings_downloads_allow_metered_subtitle">Permit downloads on mobile data. When off, downloads require Wi‑Fi.</string>
+    <string name="settings_downloads_allow_low_battery_title">Allow when battery is low</string>
+    <string name="settings_downloads_allow_low_battery_subtitle">When off, downloads wait until battery is not low.</string>
+    <string name="settings_downloads_prefer_offline_title">Prefer offline pages</string>
+    <string name="settings_downloads_prefer_offline_subtitle">When available, reader will use downloaded pages even when online.</string>
+    <string name="settings_downloads_delete_after_section">Delete after reading</string>
+    <string name="settings_downloads_delete_after_mark_title">Delete when marked as read</string>
+    <string name="settings_downloads_delete_after_mark_subtitle">Automatically remove downloads after you mark items as read.</string>
+    <string name="settings_downloads_keep_recent_title">Keep recent downloaded pages</string>
+    <string name="settings_downloads_keep_recent_subtitle">How many recently read downloaded pages stay on device before older ones are removed.</string>
+    <string name="settings_downloads_auto_retry_title">Automatic retries</string>
+    <string name="settings_downloads_auto_retry_subtitle">Retry failed downloads automatically.</string>
+    <string name="settings_downloads_max_retry_title">Max retry attempts</string>
+    <string name="settings_downloads_max_retry_subtitle">Total attempts per task before it fails.</string>
+    <string name="settings_downloads_limits_note">These limits are applied to download and prefetch workers.</string>
+    <string name="settings_downloads_clear_downloaded">Clear downloaded pages</string>
+    <string name="settings_downloads_clear_downloaded_confirm_title">Clear downloaded pages</string>
+    <string name="settings_downloads_clear_downloaded_confirm_text">Remove all downloaded HTML pages and assets from device storage?</string>
+    <string name="settings_downloads_clear_downloaded_toast">Downloaded pages cleared</string>
+    <string name="settings_downloads_clear">Clear</string>
+    <string name="settings_downloads_cancel">Cancel</string>
+    <string name="settings_downloads_max_concurrent_title">Max concurrent downloads</string>
+    <string name="settings_downloads_max_concurrent_subtitle">Limit how many page downloads run in parallel (1-6).</string>
+    <string name="settings_downloads_selection_placeholder">Select</string>
+    <string name="settings_downloads_delete_after_option">After %1$s read</string>
+    <!-- General settings -->
+    <string name="settings_general_offline_mode_title">Offline mode</string>
+    <string name="settings_general_offline_mode_subtitle">Force the app to behave as offline (skip network calls/work) even if connectivity is available.</string>
+    <!-- History -->
+    <string name="history_error_http">HTTP %1$d</string>
+    <string name="history_no_cover">No cover</string>
+    <string name="history_entries_count">Entries: %1$d</string>
+    <string name="history_chapter_range">Ch. %1$s–%2$s</string>
+    <string name="history_chapter_single">Ch. %1$s</string>
 </resources>


### PR DESCRIPTION
* Refactor: Use string resources and remove unused strings

- Replace hardcoded text in DownloadQueueScreen with string resources for better localization.
- Add new string resources for the download screen.
- Remove unused string resources.
- Fix typos in stats-related string resource keys.

* Refactor: Use string resources in DownloadQueueScreen

Extract hardcoded strings in the download queue screen into `strings.xml` to support localization and improve maintainability.

* Refactor: Use general string resources

Consolidate duplicate strings by using more generic ones like `general_cancel`, `general_pages`, and `general_series` across different UI screens.

* Use string resources for History screen

This commit replaces hardcoded strings in the History screen with string resources for better localization and management. The following strings were externalized:

- HTTP error messages
- "No cover" text for images
- Chapter range and single chapter labels
- "Entries" count text

* Refactor: Use string resources in series detail menu

* Refactor advanced settings strings

Move hardcoded strings from the advanced settings screen into `strings.xml` for localization and maintainability.

* Localize Appearance screen

Use string resources for the back button content description and the screen title for localization.

* Externalize strings on Downloads settings screen

* Refactor: Use string resources for offline mode setting

* Refactor: Use string resource for back button content description

* Refactor: Use string resources for Kavita settings messages

* Fix import order in SettingsDownloadScreen.kt

* Remove placeholder host string