### PR TITLE
Refactor browse page caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented here.
 - Network: Custom Coil `ImageLoader` now respects the max-parallel thumbnails setting via OkHttp dispatcher limits.
 - Browse: Guarded paging requests to avoid duplicate page loads during fast scrolling.
 - Browse: Search field now includes a clear (X) button that resets the query and reloads results.
+- Browse: Fresh cache no longer blocks loading additional pages; pagination continues beyond the first cached page.
 
 ## v0.2.0-beta.1
 


### PR DESCRIPTION
- Use a local variable to hold the cached page.
- Check `cachedPage.isNotEmpty()` before using the cache to prevent unnecessary UI updates and network calls when the cache is empty but valid.
- Ensure `canLoadMore` is correctly set to `true` when a valid cache is used.