### PR TITLE
Add option to disable thumbnails in Browse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented here.
 - Logging: Added rotating on-device log files with export/save/clear controls, a verbose logging toggle, sanitization of hosts/IPs/API keys, config snapshot in exported zips, and automatic pruning (12 days, 5 files).
 - Browse: Added shimmer placeholders for grid tiles and thumbnails while covers load.
 - Settings: Added “Max thumbnails in parallel” in Advanced to limit concurrent thumbnail downloads.
+- Settings: Added option to disable thumbnails in Browse for text-only results.
 
 ### Changed
 - UI: Switched theme base to `Theme.AppCompat.DayNight.NoActionBar` (required for per-app language support with Compose).

--- a/app/src/main/java/net/dom53/inkita/core/storage/AppPreferences.kt
+++ b/app/src/main/java/net/dom53/inkita/core/storage/AppPreferences.kt
@@ -95,6 +95,7 @@ class AppPreferences(
         private val KEY_VERBOSE_LOGGING = booleanPreferencesKey("verbose_logging")
         private val KEY_BROWSE_PAGE_SIZE = intPreferencesKey("browse_page_size")
         private val KEY_MAX_THUMBNAILS_PARALLEL = intPreferencesKey("max_thumbnails_parallel")
+        private val KEY_DISABLE_BROWSE_THUMBNAILS = booleanPreferencesKey("disable_browse_thumbnails")
 
         private const val REFRESH_CACHE_DEFAULT = 720
 
@@ -187,6 +188,8 @@ class AppPreferences(
         context.dataStore.data.map { prefs -> (prefs[KEY_BROWSE_PAGE_SIZE] ?: 25).coerceIn(10, 50) }
     val maxThumbnailsParallelFlow: Flow<Int> =
         context.dataStore.data.map { prefs -> (prefs[KEY_MAX_THUMBNAILS_PARALLEL] ?: 4).coerceIn(2, 6) }
+    val disableBrowseThumbnailsFlow: Flow<Boolean> =
+        context.dataStore.data.map { prefs -> prefs[KEY_DISABLE_BROWSE_THUMBNAILS] ?: false }
 
     val prefetchCollectionsAllFlow: Flow<Boolean> =
         context.dataStore.data.map { prefs -> prefs[KEY_PREFETCH_COLLECTIONS_ALL] ?: true }
@@ -458,6 +461,12 @@ class AppPreferences(
     suspend fun setMaxThumbnailsParallel(value: Int) {
         context.dataStore.edit { prefs ->
             prefs[KEY_MAX_THUMBNAILS_PARALLEL] = value.coerceIn(2, 6)
+        }
+    }
+
+    suspend fun setDisableBrowseThumbnails(disabled: Boolean) {
+        context.dataStore.edit { prefs ->
+            prefs[KEY_DISABLE_BROWSE_THUMBNAILS] = disabled
         }
     }
 

--- a/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/settings/screens/SettingsAdvancedScreen.kt
@@ -89,6 +89,7 @@ fun SettingsAdvancedScreen(
     var verboseLogging by remember { mutableStateOf(false) }
     var browsePageSize by remember { mutableStateOf(25) }
     var maxThumbnailsParallel by remember { mutableStateOf(4) }
+    var disableBrowseThumbnails by remember { mutableStateOf(false) }
     val collectionsRepo = remember { CollectionsRepositoryImpl(context, appPreferences) }
     val downloadRepo =
         remember {
@@ -150,6 +151,9 @@ fun SettingsAdvancedScreen(
     }
     LaunchedEffect(Unit) {
         appPreferences.maxThumbnailsParallelFlow.collectLatest { maxThumbnailsParallel = it }
+    }
+    LaunchedEffect(Unit) {
+        appPreferences.disableBrowseThumbnailsFlow.collectLatest { disableBrowseThumbnails = it }
     }
     LaunchedEffect(Unit) {
         val cached = runCatching { appPreferences.loadCachedCollections() }.getOrDefault(emptyList())
@@ -377,6 +381,30 @@ fun SettingsAdvancedScreen(
                 maxThumbnailsParallel.toString(),
                 style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.padding(start = 8.dp),
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.settings_browse_thumbnails_off_title),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                Text(
+                    text = stringResource(R.string.settings_browse_thumbnails_off_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(
+                checked = disableBrowseThumbnails,
+                onCheckedChange = { checked ->
+                    disableBrowseThumbnails = checked
+                    scope.launch { appPreferences.setDisableBrowseThumbnails(checked) }
+                },
             )
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,6 +132,8 @@
     <string name="settings_browse_page_size_subtitle">How many items to load per page when browsing/searching. Use lower values on slow connections.</string>
     <string name="settings_browse_thumb_parallel_title">Max thumbnails in parallel</string>
     <string name="settings_browse_thumb_parallel_subtitle">Limit parallel thumbnail downloads to reduce network spikes.</string>
+    <string name="settings_browse_thumbnails_off_title">Disable browse thumbnails</string>
+    <string name="settings_browse_thumbnails_off_subtitle">Show text-only results in Browse to save data.</string>
     <string name="settings_prefetch_allow_metered_title">Allow on cellular</string>
     <string name="settings_prefetch_allow_metered_subtitle">Enable prefetch on metered networks (mobile data).</string>
     <string name="settings_prefetch_allow_low_battery_title">Allow on low battery</string>


### PR DESCRIPTION
Adds a new setting in the "Advanced" section to disable loading thumbnails in the Browse screen. When enabled, the browse and search results will be text-only, which helps to save data.