### PR TITLE
Feature/simplify downloads display

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -158,6 +158,7 @@ dependencies {
     implementation(libs.aboutLibraries.compose)
     implementation(libs.androidx.compose.foundation.layout)
     implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.material.icons.core)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/net/dom53/inkita/MainActivity.kt
+++ b/app/src/main/java/net/dom53/inkita/MainActivity.kt
@@ -522,7 +522,12 @@ fun InkitaApp(
                     composable(MainScreen.Downloads.route) {
                         val ctx = LocalContext.current
                         val vm = remember { DownloadQueueViewModelFactory.create(ctx, cacheManager) }
-                        DownloadQueueScreen(viewModel = vm)
+                        DownloadQueueScreen(
+                            viewModel = vm,
+                            onOpenReader = { chapterId, page, sid, vid, fmt ->
+                                navController.navigate("reader/$chapterId?page=$page&sid=$sid&vid=$vid&fmt=${fmt ?: -1}")
+                            }
+                        )
                     }
                     composable(MainScreen.Settings.route) {
                         SettingsScreen(

--- a/app/src/main/java/net/dom53/inkita/MainActivity.kt
+++ b/app/src/main/java/net/dom53/inkita/MainActivity.kt
@@ -526,7 +526,7 @@ fun InkitaApp(
                             viewModel = vm,
                             onOpenReader = { chapterId, page, sid, vid, fmt ->
                                 navController.navigate("reader/$chapterId?page=$page&sid=$sid&vid=$vid&fmt=${fmt ?: -1}")
-                            }
+                            },
                         )
                     }
                     composable(MainScreen.Settings.route) {

--- a/app/src/main/java/net/dom53/inkita/core/downloadv2/strategies/ChapterImageArchiveDownloadStrategyV2.kt
+++ b/app/src/main/java/net/dom53/inkita/core/downloadv2/strategies/ChapterImageArchiveDownloadStrategyV2.kt
@@ -15,6 +15,7 @@ import net.dom53.inkita.core.storage.AppPreferences
 import net.dom53.inkita.data.local.db.dao.DownloadV2Dao
 import net.dom53.inkita.data.local.db.entity.DownloadJobV2Entity
 import net.dom53.inkita.data.local.db.entity.DownloadedItemV2Entity
+import net.dom53.inkita.domain.model.Format
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okio.buffer
@@ -46,7 +47,7 @@ class ChapterImageArchiveDownloadStrategyV2(
             if (LoggingManager.isDebugEnabled()) {
                 LoggingManager.d("ArchiveDownloadV2", "Skip enqueue; already downloaded chapter=$chapterId")
             }
-            return existing.jobId ?: -1L
+            return existing.jobId
         }
         val now = System.currentTimeMillis()
         val job =
@@ -81,6 +82,7 @@ class ChapterImageArchiveDownloadStrategyV2(
                 status = DownloadedItemV2Entity.STATUS_PENDING,
                 createdAt = now,
                 updatedAt = now,
+                format = Format.Archive,
                 error = null,
             )
         downloadDao.upsertItems(listOf(item))

--- a/app/src/main/java/net/dom53/inkita/core/downloadv2/strategies/DownloadApiStrategyV2.kt
+++ b/app/src/main/java/net/dom53/inkita/core/downloadv2/strategies/DownloadApiStrategyV2.kt
@@ -13,6 +13,7 @@ import net.dom53.inkita.core.storage.AppPreferences
 import net.dom53.inkita.data.local.db.dao.DownloadV2Dao
 import net.dom53.inkita.data.local.db.entity.DownloadJobV2Entity
 import net.dom53.inkita.data.local.db.entity.DownloadedItemV2Entity
+import net.dom53.inkita.domain.model.Format
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okio.buffer
@@ -49,7 +50,7 @@ class DownloadApiStrategyV2(
             if (LoggingManager.isDebugEnabled()) {
                 LoggingManager.d("DownloadApiV2", "Skip enqueue; already downloaded ${request.type}=$endpoint")
             }
-            return existing.jobId ?: -1L
+            return existing.jobId
         }
         val job =
             DownloadJobV2Entity(
@@ -83,6 +84,7 @@ class DownloadApiStrategyV2(
                 status = DownloadedItemV2Entity.STATUS_PENDING,
                 createdAt = now,
                 updatedAt = now,
+                format = translateFormatFromRequest(request.format),
                 error = null,
             )
         downloadDao.upsertItems(listOf(item))
@@ -229,5 +231,15 @@ class DownloadApiStrategyV2(
 
     companion object {
         const val FORMAT_DOWNLOAD = "download"
+    }
+}
+
+private fun translateFormatFromRequest(incomingFormat: String): Format {
+    return when(incomingFormat) {
+        PdfDownloadStrategyV2.FORMAT_PDF -> Format.Pdf
+        EpubDownloadStrategyV2.FORMAT_EPUB -> Format.Epub
+        ChapterImageArchiveDownloadStrategyV2.FORMAT_IMAGE -> Format.Image
+        ChapterImageArchiveDownloadStrategyV2.FORMAT_ARCHIVE -> Format.Archive
+        else -> Format.Unknown
     }
 }

--- a/app/src/main/java/net/dom53/inkita/core/downloadv2/strategies/DownloadApiStrategyV2.kt
+++ b/app/src/main/java/net/dom53/inkita/core/downloadv2/strategies/DownloadApiStrategyV2.kt
@@ -234,12 +234,11 @@ class DownloadApiStrategyV2(
     }
 }
 
-private fun translateFormatFromRequest(incomingFormat: String): Format {
-    return when(incomingFormat) {
+private fun translateFormatFromRequest(incomingFormat: String): Format =
+    when (incomingFormat) {
         PdfDownloadStrategyV2.FORMAT_PDF -> Format.Pdf
         EpubDownloadStrategyV2.FORMAT_EPUB -> Format.Epub
         ChapterImageArchiveDownloadStrategyV2.FORMAT_IMAGE -> Format.Image
         ChapterImageArchiveDownloadStrategyV2.FORMAT_ARCHIVE -> Format.Archive
         else -> Format.Unknown
     }
-}

--- a/app/src/main/java/net/dom53/inkita/core/downloadv2/strategies/EpubDownloadStrategyV2.kt
+++ b/app/src/main/java/net/dom53/inkita/core/downloadv2/strategies/EpubDownloadStrategyV2.kt
@@ -16,6 +16,7 @@ import net.dom53.inkita.core.storage.AppPreferences
 import net.dom53.inkita.data.local.db.dao.DownloadV2Dao
 import net.dom53.inkita.data.local.db.entity.DownloadJobV2Entity
 import net.dom53.inkita.data.local.db.entity.DownloadedItemV2Entity
+import net.dom53.inkita.domain.model.Format
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okio.buffer
@@ -123,6 +124,7 @@ class EpubDownloadStrategyV2(
                     status = DownloadedItemV2Entity.STATUS_PENDING,
                     createdAt = now,
                     updatedAt = now,
+                    format = Format.Epub,
                     error = null,
                 )
             }

--- a/app/src/main/java/net/dom53/inkita/core/downloadv2/strategies/PdfDownloadStrategyV2.kt
+++ b/app/src/main/java/net/dom53/inkita/core/downloadv2/strategies/PdfDownloadStrategyV2.kt
@@ -15,6 +15,7 @@ import net.dom53.inkita.core.storage.AppPreferences
 import net.dom53.inkita.data.local.db.dao.DownloadV2Dao
 import net.dom53.inkita.data.local.db.entity.DownloadJobV2Entity
 import net.dom53.inkita.data.local.db.entity.DownloadedItemV2Entity
+import net.dom53.inkita.domain.model.Format
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okio.buffer
@@ -83,6 +84,7 @@ class PdfDownloadStrategyV2(
                 status = DownloadedItemV2Entity.STATUS_PENDING,
                 createdAt = now,
                 updatedAt = now,
+                format = Format.Pdf,
                 error = null,
             )
         downloadDao.upsertItems(listOf(item))

--- a/app/src/main/java/net/dom53/inkita/data/local/db/InkitaDatabase.kt
+++ b/app/src/main/java/net/dom53/inkita/data/local/db/InkitaDatabase.kt
@@ -51,7 +51,7 @@ import net.dom53.inkita.data.local.db.entity.DownloadedItemV2Entity
         DownloadedItemV2Entity::class,
         net.dom53.inkita.data.local.db.entity.LocalReaderProgressEntity::class,
     ],
-    version = 20,
+    version = 21,
     exportSchema = false,
 )
 abstract class InkitaDatabase : RoomDatabase() {
@@ -70,8 +70,8 @@ abstract class InkitaDatabase : RoomDatabase() {
 
         private val MIGRATION_1_2 =
             object : Migration(1, 2) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL(
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_series_refs(
                             tabType TEXT NOT NULL,
@@ -86,8 +86,8 @@ abstract class InkitaDatabase : RoomDatabase() {
             }
         private val MIGRATION_2_3 =
             object : Migration(2, 3) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL(
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_browse_refs(
                             queryKey TEXT NOT NULL,
@@ -102,8 +102,8 @@ abstract class InkitaDatabase : RoomDatabase() {
             }
         private val MIGRATION_3_4 =
             object : Migration(3, 4) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL(
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_series_detail(
                             seriesId INTEGER NOT NULL PRIMARY KEY,
@@ -117,7 +117,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_volumes(
                             id INTEGER NOT NULL PRIMARY KEY,
@@ -140,8 +140,8 @@ abstract class InkitaDatabase : RoomDatabase() {
             }
         private val MIGRATION_4_5 =
             object : Migration(4, 5) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL(
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_pages(
                             chapterId INTEGER NOT NULL,
@@ -156,17 +156,17 @@ abstract class InkitaDatabase : RoomDatabase() {
             }
         private val MIGRATION_5_6 =
             object : Migration(5, 6) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL("ALTER TABLE cached_series_detail ADD COLUMN metadataSummary TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail ADD COLUMN metadataWriters TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail ADD COLUMN metadataTags TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail ADD COLUMN metadataPublicationStatus INTEGER")
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE cached_series_detail ADD COLUMN metadataSummary TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail ADD COLUMN metadataWriters TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail ADD COLUMN metadataTags TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail ADD COLUMN metadataPublicationStatus INTEGER")
                 }
             }
         private val MIGRATION_6_7 =
             object : Migration(6, 7) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL(
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_chapters(
                             volumeId INTEGER NOT NULL,
@@ -182,8 +182,8 @@ abstract class InkitaDatabase : RoomDatabase() {
             }
         private val MIGRATION_7_8 =
             object : Migration(7, 8) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL(
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS download_tasks(
                             id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -201,7 +201,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS downloaded_pages(
                             seriesId INTEGER NOT NULL,
@@ -222,23 +222,23 @@ abstract class InkitaDatabase : RoomDatabase() {
             }
         private val MIGRATION_8_9 =
             object : Migration(8, 9) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL("ALTER TABLE download_tasks ADD COLUMN workId TEXT")
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE download_tasks ADD COLUMN workId TEXT")
                 }
             }
         private val MIGRATION_9_10 =
             object : Migration(9, 10) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL("ALTER TABLE download_tasks ADD COLUMN progress INTEGER NOT NULL DEFAULT 0")
-                    database.execSQL("ALTER TABLE download_tasks ADD COLUMN total INTEGER NOT NULL DEFAULT 0")
-                    database.execSQL("ALTER TABLE download_tasks ADD COLUMN bytes INTEGER NOT NULL DEFAULT 0")
-                    database.execSQL("ALTER TABLE download_tasks ADD COLUMN bytesTotal INTEGER NOT NULL DEFAULT 0")
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE download_tasks ADD COLUMN progress INTEGER NOT NULL DEFAULT 0")
+                    db.execSQL("ALTER TABLE download_tasks ADD COLUMN total INTEGER NOT NULL DEFAULT 0")
+                    db.execSQL("ALTER TABLE download_tasks ADD COLUMN bytes INTEGER NOT NULL DEFAULT 0")
+                    db.execSQL("ALTER TABLE download_tasks ADD COLUMN bytesTotal INTEGER NOT NULL DEFAULT 0")
                 }
             }
         private val MIGRATION_10_11 =
             object : Migration(10, 11) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL(
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS local_progress(
                             chapterId INTEGER NOT NULL PRIMARY KEY,
@@ -255,15 +255,15 @@ abstract class InkitaDatabase : RoomDatabase() {
             }
         private val MIGRATION_11_12 =
             object : Migration(11, 12) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL("ALTER TABLE cached_chapters ADD COLUMN isSpecial INTEGER NOT NULL DEFAULT 0")
-                    database.execSQL("ALTER TABLE cached_series_detail ADD COLUMN specialsVolumeIds TEXT")
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE cached_chapters ADD COLUMN isSpecial INTEGER NOT NULL DEFAULT 0")
+                    db.execSQL("ALTER TABLE cached_series_detail ADD COLUMN specialsVolumeIds TEXT")
                 }
             }
         private val MIGRATION_12_13 =
             object : Migration(12, 13) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL(
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_series_v2(
                             id INTEGER NOT NULL PRIMARY KEY,
@@ -282,7 +282,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_series_list_refs_v2(
                             listType TEXT NOT NULL,
@@ -294,7 +294,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_collections_v2(
                             id INTEGER NOT NULL PRIMARY KEY,
@@ -303,7 +303,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_collection_refs_v2(
                             listType TEXT NOT NULL,
@@ -314,7 +314,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_reading_lists_v2(
                             id INTEGER NOT NULL PRIMARY KEY,
@@ -324,7 +324,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_reading_list_refs_v2(
                             listType TEXT NOT NULL,
@@ -335,7 +335,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_people_v2(
                             id INTEGER NOT NULL PRIMARY KEY,
@@ -344,7 +344,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_person_refs_v2(
                             listType TEXT NOT NULL,
@@ -360,19 +360,19 @@ abstract class InkitaDatabase : RoomDatabase() {
             }
         private val MIGRATION_13_14 =
             object : Migration(13, 14) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL("DROP TABLE IF EXISTS cached_series")
-                    database.execSQL("DROP TABLE IF EXISTS cached_series_refs")
-                    database.execSQL("DROP TABLE IF EXISTS cached_browse_refs")
-                    database.execSQL("DROP TABLE IF EXISTS cached_series_detail")
-                    database.execSQL("DROP TABLE IF EXISTS cached_volumes")
-                    database.execSQL("DROP TABLE IF EXISTS cached_chapters")
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("DROP TABLE IF EXISTS cached_series")
+                    db.execSQL("DROP TABLE IF EXISTS cached_series_refs")
+                    db.execSQL("DROP TABLE IF EXISTS cached_browse_refs")
+                    db.execSQL("DROP TABLE IF EXISTS cached_series_detail")
+                    db.execSQL("DROP TABLE IF EXISTS cached_volumes")
+                    db.execSQL("DROP TABLE IF EXISTS cached_chapters")
                 }
             }
         private val MIGRATION_14_15 =
             object : Migration(14, 15) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL(
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_series_detail_v2(
                             seriesId INTEGER NOT NULL PRIMARY KEY,
@@ -392,7 +392,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_series_detail_related_refs_v2(
                             seriesId INTEGER NOT NULL,
@@ -405,7 +405,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_volumes_v2(
                             id INTEGER NOT NULL PRIMARY KEY,
@@ -424,7 +424,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_series_volume_refs_v2(
                             seriesId INTEGER NOT NULL,
@@ -435,7 +435,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_chapters_v2(
                             id INTEGER NOT NULL PRIMARY KEY,
@@ -449,7 +449,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS cached_volume_chapter_refs_v2(
                             volumeId INTEGER NOT NULL,
@@ -464,26 +464,26 @@ abstract class InkitaDatabase : RoomDatabase() {
             }
         private val MIGRATION_15_16 =
             object : Migration(15, 16) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN seriesJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN metadataJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN detailJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN relatedJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN ratingJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN continuePointJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN readerProgressJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN timeLeftJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN collectionsJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN readingListsJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN bookmarksJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN annotationsJson TEXT")
-                    database.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN seriesDetailPlusJson TEXT")
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN seriesJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN metadataJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN detailJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN relatedJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN ratingJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN continuePointJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN readerProgressJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN timeLeftJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN collectionsJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN readingListsJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN bookmarksJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN annotationsJson TEXT")
+                    db.execSQL("ALTER TABLE cached_series_detail_v2 ADD COLUMN seriesDetailPlusJson TEXT")
                 }
             }
         private val MIGRATION_16_17 =
             object : Migration(16, 17) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL(
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS download_jobs_v2(
                             id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -504,7 +504,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         )
                         """.trimIndent(),
                     )
-                    database.execSQL(
+                    db.execSQL(
                         """
                         CREATE TABLE IF NOT EXISTS download_items_v2(
                             id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -527,22 +527,39 @@ abstract class InkitaDatabase : RoomDatabase() {
             }
         private val MIGRATION_17_18 =
             object : Migration(17, 18) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL("ALTER TABLE download_items_v2 ADD COLUMN seriesId INTEGER")
-                    database.execSQL("ALTER TABLE download_items_v2 ADD COLUMN volumeId INTEGER")
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE download_items_v2 ADD COLUMN seriesId INTEGER")
+                    db.execSQL("ALTER TABLE download_items_v2 ADD COLUMN volumeId INTEGER")
                 }
             }
         private val MIGRATION_18_19 =
             object : Migration(18, 19) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL("ALTER TABLE download_jobs_v2 ADD COLUMN retryCount INTEGER NOT NULL DEFAULT 0")
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE download_jobs_v2 ADD COLUMN retryCount INTEGER NOT NULL DEFAULT 0")
                 }
             }
         private val MIGRATION_19_20 =
             object : Migration(19, 20) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    database.execSQL("DROP TABLE IF EXISTS download_tasks")
-                    database.execSQL("DROP TABLE IF EXISTS downloaded_pages")
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("DROP TABLE IF EXISTS download_tasks")
+                    db.execSQL("DROP TABLE IF EXISTS downloaded_pages")
+                }
+            }
+
+        private val MIGRATION_20_21 =
+            object : Migration(20, 21) {
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE download_items_v2 ADD COLUMN format TEXT")
+                    db.execSQL("""
+                        UPDATE download_items_v2
+                        SET format = CASE
+                            WHEN localPath LIKE '%.epub' THEN 'Epub'
+                            WHEN localPath LIKE '%.pdf' THEN 'Pdf'
+                            WHEN localPath LIKE '%.cbz' OR localPath LIKE '%.zip' OR localPath LIKE '%.rar' OR localPath LIKE '%.cbr' OR localPath LIKE '%.tar.gz' OR localPath LIKE '%.7zip' OR localPath LIKE '%.7z' OR localPath LIKE '%.cb7' OR localPath LIKE '%.cbt' THEN 'Archive'
+                            WHEN localPath LIKE '%.png' OR localPath LIKE '%.jpeg' OR localPath LIKE '%.jpg' OR localPath LIKE '%.webp' OR localPath LIKE '%.gif' OR localPath LIKE '%.avif' THEN 'Image'
+                            ELSE 'Unknown'
+                        END
+                        """.trimIndent())
                 }
             }
 
@@ -573,6 +590,7 @@ abstract class InkitaDatabase : RoomDatabase() {
                         MIGRATION_17_18,
                         MIGRATION_18_19,
                         MIGRATION_19_20,
+                        MIGRATION_20_21,
                     ).build()
                     .also { INSTANCE = it }
             }

--- a/app/src/main/java/net/dom53/inkita/data/local/db/InkitaDatabase.kt
+++ b/app/src/main/java/net/dom53/inkita/data/local/db/InkitaDatabase.kt
@@ -550,7 +550,8 @@ abstract class InkitaDatabase : RoomDatabase() {
             object : Migration(20, 21) {
                 override fun migrate(db: SupportSQLiteDatabase) {
                     db.execSQL("ALTER TABLE download_items_v2 ADD COLUMN format TEXT")
-                    db.execSQL("""
+                    db.execSQL(
+                        """
                         UPDATE download_items_v2
                         SET format = CASE
                             WHEN localPath LIKE '%.epub' THEN 'Epub'
@@ -559,7 +560,8 @@ abstract class InkitaDatabase : RoomDatabase() {
                             WHEN localPath LIKE '%.png' OR localPath LIKE '%.jpeg' OR localPath LIKE '%.jpg' OR localPath LIKE '%.webp' OR localPath LIKE '%.gif' OR localPath LIKE '%.avif' THEN 'Image'
                             ELSE 'Unknown'
                         END
-                        """.trimIndent())
+                        """.trimIndent(),
+                    )
                 }
             }
 

--- a/app/src/main/java/net/dom53/inkita/data/local/db/entity/DownloadedItemV2Entity.kt
+++ b/app/src/main/java/net/dom53/inkita/data/local/db/entity/DownloadedItemV2Entity.kt
@@ -2,6 +2,7 @@ package net.dom53.inkita.data.local.db.entity
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import net.dom53.inkita.domain.model.Format
 
 @Entity(tableName = "download_items_v2")
 data class DownloadedItemV2Entity(
@@ -19,6 +20,7 @@ data class DownloadedItemV2Entity(
     val status: String,
     val createdAt: Long,
     val updatedAt: Long,
+    val format: Format?,
     val error: String?,
 ) {
     companion object {

--- a/app/src/main/java/net/dom53/inkita/data/repository/ReaderRepositoryImpl.kt
+++ b/app/src/main/java/net/dom53/inkita/data/repository/ReaderRepositoryImpl.kt
@@ -16,6 +16,7 @@ import net.dom53.inkita.data.local.db.entity.DownloadedItemV2Entity
 import net.dom53.inkita.data.local.db.entity.LocalReaderProgressEntity
 import net.dom53.inkita.data.mapper.toDomain
 import net.dom53.inkita.data.mapper.toDto
+import net.dom53.inkita.domain.model.Format
 import net.dom53.inkita.domain.model.ReaderBookInfo
 import net.dom53.inkita.domain.model.ReaderChapterNav
 import net.dom53.inkita.domain.model.ReaderImageResult
@@ -369,6 +370,7 @@ class ReaderRepositoryImpl(
                 status = DownloadedItemV2Entity.STATUS_COMPLETED,
                 createdAt = now,
                 updatedAt = now,
+                format = Format.Pdf,
                 error = null,
             )
         dao.upsertItems(listOf(item))

--- a/app/src/main/java/net/dom53/inkita/ui/download/DownloadQueueScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/download/DownloadQueueScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.unit.dp
 import net.dom53.inkita.R
 import net.dom53.inkita.data.local.db.entity.DownloadJobV2Entity
 import net.dom53.inkita.data.local.db.entity.DownloadedItemV2Entity
-import net.dom53.inkita.domain.model.Format
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -394,26 +393,13 @@ private fun DownloadedRow(
                             item = item,
                             lookup = lookup,
                             onOpen = {
-                                val fileType = if (item.localPath == null) {
-                                        return@DownloadedItem
-                                    } else if (item.localPath.endsWith(".epub")) {
-                                        Format.Epub
-                                    } else if (item.localPath.endsWith(".pdf")) {
-                                        Format.Pdf
-                                    } else if (item.localPath.endsWith(".jpg") || item.localPath.endsWith(".png")) {
-                                        Format.Image
-                                    } else if (item.localPath.endsWith(".cbz")) {
-                                        Format.Archive
-                                    } else {
-                                        Format.Unknown
-                                    }
-                                if (item.chapterId != null && item.seriesId != null && item.volumeId != null) {
+                                if (item.chapterId != null && item.seriesId != null && item.volumeId != null && item.format != null) {
                                     onOpenReader(
                                         item.chapterId,
                                         item.page ?: 0,
                                         item.seriesId,
                                         item.volumeId,
-                                        fileType.ordinal
+                                        item.format.ordinal
                                     )
                                 }
                             },

--- a/app/src/main/java/net/dom53/inkita/ui/download/DownloadQueueScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/download/DownloadQueueScreen.kt
@@ -65,20 +65,23 @@ private fun formatBytes(value: Long): String {
 }
 
 enum class DownloadTabs {
-    TAB_QUEUE, TAB_COMPLETED, TAB_DOWNLOADED
+    TAB_QUEUE,
+    TAB_COMPLETED,
+    TAB_DOWNLOADED,
 }
 
 @Composable
 fun DownloadQueueScreen(
     viewModel: DownloadQueueViewModel,
-    onOpenReader: (chapterId: Int, page: Int, seriesId: Int, volumeId: Int, formatId: Int?) -> Unit
+    onOpenReader: (chapterId: Int, page: Int, seriesId: Int, volumeId: Int, formatId: Int?) -> Unit,
 ) {
     val tasks by viewModel.tasks.collectAsState()
     val downloaded by viewModel.downloaded.collectAsState()
-    val downloadedBySeries = downloaded
-        .filter{it.seriesId != null}
-        .groupBy { it.seriesId ?: 0 }
-        .map { Pair(it.key, it.value) }
+    val downloadedBySeries =
+        downloaded
+            .filter { it.seriesId != null }
+            .groupBy { it.seriesId ?: 0 }
+            .map { Pair(it.key, it.value) }
     val lookup by viewModel.lookup.collectAsState()
     var selectedTab by remember { mutableStateOf(DownloadTabs.TAB_QUEUE) }
 
@@ -137,7 +140,7 @@ fun DownloadQueueScreen(
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
-                        contentPadding = PaddingValues(0.dp, 4.dp)
+                        contentPadding = PaddingValues(0.dp, 4.dp),
                     ) {
                         items(downloadedBySeries, key = { it.first }) { downloads ->
                             DownloadedRow(
@@ -145,7 +148,7 @@ fun DownloadQueueScreen(
                                 downloads = downloads.second,
                                 lookup = lookup,
                                 onOpenReader = onOpenReader,
-                                deleteDownloaded = viewModel::deleteDownloaded
+                                deleteDownloaded = viewModel::deleteDownloaded,
                             )
                         }
                     }
@@ -174,7 +177,7 @@ fun DownloadQueueScreen(
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
-                        contentPadding = PaddingValues(0.dp, 4.dp)
+                        contentPadding = PaddingValues(0.dp, 4.dp),
                     ) {
                         items(visibleTasks, key = { it.id }) { task ->
                             TaskRow(
@@ -217,12 +220,13 @@ private fun TaskRow(
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Row(
@@ -344,7 +348,7 @@ private fun DownloadedRow(
     downloads: List<DownloadedItemV2Entity>,
     lookup: DownloadLookup,
     onOpenReader: (chapterId: Int, page: Int, seriesId: Int, volumeId: Int, formatId: Int?) -> Unit,
-    deleteDownloaded: (itemId: Long) -> Unit
+    deleteDownloaded: (itemId: Long) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
@@ -352,22 +356,24 @@ private fun DownloadedRow(
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable(
-                        interactionSource = interactionSource,
-                        indication = null,
-                    ) { expanded = !expanded },
-                horizontalArrangement = Arrangement.SpaceBetween
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable(
+                            interactionSource = interactionSource,
+                            indication = null,
+                        ) { expanded = !expanded },
+                horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 val seriesLabel = lookup.seriesNames[seriesId] ?: "—"
                 Text(
@@ -375,18 +381,19 @@ private fun DownloadedRow(
                     style = MaterialTheme.typography.titleMedium,
                 )
                 Icon(
-                    modifier = Modifier.indication(
-                        interactionSource = interactionSource,
-                        indication = ripple(bounded = false)
-                    ),
+                    modifier =
+                        Modifier.indication(
+                            interactionSource = interactionSource,
+                            indication = ripple(bounded = false),
+                        ),
                     imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                    contentDescription = stringResource(R.string.download_completed_toggle_description)
+                    contentDescription = stringResource(R.string.download_completed_toggle_description),
                 )
             }
             AnimatedVisibility(visible = expanded) {
                 Column(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     downloads.forEach { item ->
                         DownloadedItem(
@@ -399,11 +406,11 @@ private fun DownloadedRow(
                                         item.page ?: 0,
                                         item.seriesId,
                                         item.volumeId,
-                                        item.format.ordinal
+                                        item.format.ordinal,
                                     )
                                 }
                             },
-                            onDelete = { deleteDownloaded(item.id) }
+                            onDelete = { deleteDownloaded(item.id) },
                         )
                     }
                 }
@@ -417,14 +424,14 @@ private fun DownloadedItem(
     item: DownloadedItemV2Entity,
     lookup: DownloadLookup,
     onOpen: () -> Unit,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
 ) {
     val volumeLabel = lookup.volumeNames[item.volumeId]
     val chapterLabel = lookup.chapterTitles[item.chapterId]
 
     Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
             if (volumeLabel != null) {

--- a/app/src/main/java/net/dom53/inkita/ui/download/DownloadQueueScreen.kt
+++ b/app/src/main/java/net/dom53/inkita/ui/download/DownloadQueueScreen.kt
@@ -2,27 +2,36 @@ package net.dom53.inkita.ui.download
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -35,6 +44,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import net.dom53.inkita.R
 import net.dom53.inkita.data.local.db.entity.DownloadJobV2Entity
 import net.dom53.inkita.data.local.db.entity.DownloadedItemV2Entity
@@ -45,7 +55,7 @@ import java.util.Locale
 
 private val dateFormatter by lazy { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()) }
 
-private fun formatDate(ts: Long): String = if (ts > 0) dateFormatter.format(Date(ts)) else "-"
+private fun formatDate(ts: Long): String = if (ts > 0) dateFormatter.format(Date(ts)) else "—"
 
 private fun formatBytes(value: Long): String {
     if (value <= 0) return "0 B"
@@ -59,13 +69,20 @@ private fun formatBytes(value: Long): String {
     return String.format(Locale.getDefault(), "%.1f %s", v, units[idx])
 }
 
+enum class DownloadTabs {
+    TAB_QUEUE, TAB_COMPLETED, TAB_DOWNLOADED
+}
+
 @Composable
 fun DownloadQueueScreen(viewModel: DownloadQueueViewModel) {
     val tasks by viewModel.tasks.collectAsState()
     val downloaded by viewModel.downloaded.collectAsState()
+    val downloadedBySeries = downloaded
+        .filter{it.seriesId != null}
+        .groupBy { it.seriesId ?: 0 }
+        .map { Pair(it.key, it.value) }
     val lookup by viewModel.lookup.collectAsState()
-    val context = LocalContext.current
-    var selectedTab by remember { mutableStateOf(0) }
+    var selectedTab by remember { mutableStateOf(DownloadTabs.TAB_QUEUE) }
 
     val queueStates =
         listOf(
@@ -81,8 +98,8 @@ fun DownloadQueueScreen(viewModel: DownloadQueueViewModel) {
     val downloadedCount = downloaded.size
     val visibleTasks =
         when (selectedTab) {
-            0 -> tasks.filter { it.status in queueStates }
-            1 -> tasks.filter { it.status in completedStates }
+            DownloadTabs.TAB_QUEUE -> tasks.filter { it.status in queueStates }
+            DownloadTabs.TAB_COMPLETED -> tasks.filter { it.status in completedStates }
             else -> emptyList()
         }
 
@@ -94,20 +111,20 @@ fun DownloadQueueScreen(viewModel: DownloadQueueViewModel) {
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Text(stringResource(R.string.download_screen_title), style = MaterialTheme.typography.headlineSmall)
-        TabRow(selectedTabIndex = selectedTab) {
-            Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 }) {
+        TabRow(selectedTabIndex = selectedTab.ordinal) {
+            Tab(selected = selectedTab == DownloadTabs.TAB_QUEUE, onClick = { selectedTab = DownloadTabs.TAB_QUEUE }) {
                 Text(
                     "${stringResource(R.string.general_queue)} ($queueCount)",
                     modifier = Modifier.padding(12.dp),
                 )
             }
-            Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 }) {
+            Tab(selected = selectedTab == DownloadTabs.TAB_COMPLETED, onClick = { selectedTab = DownloadTabs.TAB_COMPLETED }) {
                 Text(
                     "${stringResource(R.string.general_completed)} ($completedCount)",
                     modifier = Modifier.padding(12.dp),
                 )
             }
-            Tab(selected = selectedTab == 2, onClick = { selectedTab = 2 }) {
+            Tab(selected = selectedTab == DownloadTabs.TAB_DOWNLOADED, onClick = { selectedTab = DownloadTabs.TAB_DOWNLOADED }) {
                 Text(
                     "${stringResource(R.string.general_downloaded)} ($downloadedCount)",
                     modifier = Modifier.padding(12.dp),
@@ -115,53 +132,28 @@ fun DownloadQueueScreen(viewModel: DownloadQueueViewModel) {
             }
         }
         when (selectedTab) {
-            2 -> {
+            DownloadTabs.TAB_DOWNLOADED -> {
                 if (downloaded.isEmpty()) {
                     EmptyState(text = stringResource(R.string.download_empty_downloaded))
                 } else {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
+                        contentPadding = PaddingValues(0.dp, 4.dp)
                     ) {
-                        itemsIndexed(
-                            downloaded,
-                            key = { _, item -> item.id },
-                        ) { _, page ->
+                        items(downloadedBySeries, key = { it.first }) { downloads ->
                             DownloadedRow(
-                                page = page,
+                                seriesId = downloads.first,
+                                downloads = downloads.second,
                                 lookup = lookup,
-                                onOpen = {
-                                    val path = page.localPath ?: return@DownloadedRow
-                                    val uri =
-                                        if (path.startsWith("file://") || path.startsWith("content://")) {
-                                            Uri.parse(path)
-                                        } else {
-                                            Uri.fromFile(File(path))
-                                        }
-                                    val mime =
-                                        if (page.type == DownloadedItemV2Entity.TYPE_FILE) {
-                                            if (path.endsWith(".pdf")) {
-                                                "application/pdf"
-                                            } else {
-                                                "application/octet-stream"
-                                            }
-                                        } else {
-                                            "text/html"
-                                        }
-                                    val intent =
-                                        Intent(Intent.ACTION_VIEW)
-                                            .setDataAndType(uri, mime)
-                                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                    runCatching { context.startActivity(intent) }
-                                },
-                                onDelete = { viewModel.deleteDownloaded(page.id) },
+                                deleteDownloaded = viewModel::deleteDownloaded
                             )
                         }
                     }
                 }
             }
             else -> {
-                if (selectedTab == 1) {
+                if (selectedTab == DownloadTabs.TAB_COMPLETED) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.End,
@@ -173,7 +165,7 @@ fun DownloadQueueScreen(viewModel: DownloadQueueViewModel) {
                 }
                 if (visibleTasks.isEmpty()) {
                     val label =
-                        if (selectedTab == 0) {
+                        if (selectedTab == DownloadTabs.TAB_QUEUE) {
                             stringResource(R.string.download_empty_queue)
                         } else {
                             stringResource(R.string.download_empty_completed)
@@ -183,6 +175,7 @@ fun DownloadQueueScreen(viewModel: DownloadQueueViewModel) {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
+                        contentPadding = PaddingValues(0.dp, 4.dp)
                     ) {
                         items(visibleTasks, key = { it.id }) { task ->
                             TaskRow(
@@ -219,15 +212,18 @@ private fun TaskRow(
             DownloadJobV2Entity.TYPE_SERIES -> stringResource(R.string.general_series)
             else -> task.type
         }
-    val seriesLabel = formatLabel(task.seriesId, lookup.seriesNames[task.seriesId])
-    val volumeLabel = formatLabel(task.volumeId, lookup.volumeNames[task.volumeId])
-    val chapterLabelText = formatLabel(task.chapterId, lookup.chapterTitles[task.chapterId])
-    Card(
+    val seriesLabel = lookup.seriesNames[task.seriesId] ?: "—"
+    val volumeLabel = lookup.volumeNames[task.volumeId]
+    val chapterLabelText = lookup.chapterTitles[task.chapterId]
+    ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Row(
@@ -244,35 +240,22 @@ private fun TaskRow(
                 )
                 DownloadStatusChip(status = task.status)
             }
-            if (task.seriesId != null) {
-                Text(
-                    text = stringResource(R.string.download_info_series, seriesLabel),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                if (volumeLabel != null) {
+                    Text(
+                        text = "$volumeLabel:",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                if (chapterLabelText != null) {
+                    Text(
+                        text = chapterLabelText,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
-            if (task.volumeId != null) {
-                Text(
-                    text = stringResource(R.string.download_info_volume, volumeLabel),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            if (task.chapterId != null) {
-                Text(
-                    text = stringResource(R.string.download_info_chapter, chapterLabelText),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            val chapterLabel = task.chapterId?.toString() ?: "-"
-            val total = task.totalItems ?: 0
-            val pageEnd = if (total > 0) total - 1 else "-"
-            Text(
-                stringResource(R.string.download_item_chapter_pages, chapterLabel, 0, pageEnd),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 if (task.createdAt > 0) {
                     Text(
@@ -289,7 +272,7 @@ private fun TaskRow(
                     )
                 }
             }
-            if ((task.totalItems ?: 0) > 0) {
+            if ((task.totalItems ?: 0) > 0 && task.totalItems != task.completedItems) {
                 val total = task.totalItems ?: 0
                 val progress = task.completedItems ?: 0
                 val pct = (progress * 100f / total).toInt().coerceIn(0, 100)
@@ -358,81 +341,146 @@ private fun TaskRow(
 
 @Composable
 private fun DownloadedRow(
-    page: DownloadedItemV2Entity,
+    seriesId: Int,
+    downloads: List<DownloadedItemV2Entity>,
     lookup: DownloadLookup,
-    onOpen: () -> Unit,
-    onDelete: () -> Unit,
+    deleteDownloaded: (itemId: Long) -> Unit
 ) {
-    Card(
+    var expanded by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    val interactionSource = remember { MutableInteractionSource() }
+
+    ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            val seriesLabel = formatLabel(page.seriesId, lookup.seriesNames[page.seriesId])
-            val volumeLabel = formatLabel(page.volumeId, lookup.volumeNames[page.volumeId])
-            val chapterLabel = formatLabel(page.chapterId, lookup.chapterTitles[page.chapterId])
+            Row(
+                modifier = Modifier.fillMaxWidth().clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                ) { expanded = !expanded },
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                val seriesLabel = lookup.seriesNames[seriesId] ?: "—"
+                Text(
+                    stringResource(R.string.download_complete_series_group, seriesLabel, downloads.size),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Icon(
+                    modifier = Modifier.indication(
+                        interactionSource = interactionSource,
+                        indication = ripple(bounded = false)
+                    ),
+                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    contentDescription = stringResource(R.string.download_completed_toggle_description)
+                )
+            }
+            AnimatedVisibility(visible = expanded) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    downloads.forEach { item ->
+                        DownloadedItem(
+                            item = item,
+                            lookup = lookup,
+                            onOpen = {
+                                val path = item.localPath ?: return@DownloadedItem
+                                val uri =
+                                    if (path.startsWith("file://") || path.startsWith("content://")) {
+                                        path.toUri()
+                                    } else {
+                                        Uri.fromFile(File(path))
+                                    }
+                                val mime =
+                                    if (item.type == DownloadedItemV2Entity.TYPE_FILE) {
+                                        if (path.endsWith(".pdf")) {
+                                            "application/pdf"
+                                        } else {
+                                            "application/octet-stream"
+                                        }
+                                    } else {
+                                        "text/html"
+                                    }
+                                val intent =
+                                    Intent(Intent.ACTION_VIEW)
+                                        .setDataAndType(uri, mime)
+                                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                runCatching { context.startActivity(intent) }
+                            },
+                            onDelete = { deleteDownloaded(item.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadedItem(
+    item: DownloadedItemV2Entity,
+    lookup: DownloadLookup,
+    onOpen: () -> Unit,
+    onDelete: () -> Unit
+) {
+    val volumeLabel = lookup.volumeNames[item.volumeId]
+    val chapterLabel = lookup.chapterTitles[item.chapterId]
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            if (volumeLabel != null) {
+                Text(
+                    text = volumeLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (chapterLabel != null) {
+                Text(
+                    text = chapterLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             Text(
-                stringResource(
-                    R.string.download_item_v2_title,
-                    page.id,
-                    page.chapterId ?: "-",
-                    page.page ?: "-",
-                ),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            if (page.seriesId != null) {
-                Text(
-                    text = stringResource(R.string.download_info_series, seriesLabel),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            if (page.volumeId != null) {
-                Text(
-                    text = stringResource(R.string.download_info_volume, volumeLabel),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            if (page.chapterId != null) {
-                Text(
-                    text = stringResource(R.string.download_info_chapter, chapterLabel),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            DownloadStatusChip(status = page.status)
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(
-                    stringResource(R.string.download_completed_updated, formatDate(page.updatedAt)),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Text(
-                    stringResource(R.string.download_completed_size, formatBytes(page.bytes ?: 0L)),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Text(
-                page.localPath ?: "-",
+                stringResource(R.string.download_completed_size, formatBytes(item.bytes ?: 0L)),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                FilledTonalButton(onClick = onOpen) {
-                    Text(stringResource(R.string.download_completed_open))
-                }
-                OutlinedButton(onClick = onDelete, modifier = Modifier.padding(start = 8.dp)) {
-                    Text(stringResource(R.string.download_completed_delete))
-                }
+            Text(
+                stringResource(R.string.download_completed_updated, formatDate(item.updatedAt)),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (item.localPath != null) {
+            Text(
+                item.localPath,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilledTonalButton(onClick = onOpen) {
+                Text(stringResource(R.string.download_completed_open))
+            }
+            OutlinedButton(onClick = onDelete, modifier = Modifier.padding(start = 8.dp)) {
+                Text(stringResource(R.string.download_completed_delete))
             }
         }
     }
@@ -462,18 +510,6 @@ private fun DownloadStatusChip(status: String) {
                 disabledLabelColor = fg,
             ),
     )
-}
-
-private fun formatLabel(
-    id: Int?,
-    name: String?,
-): String {
-    if (id == null) return "-"
-    return if (name.isNullOrBlank()) {
-        "#$id"
-    } else {
-        "$name (#$id)"
-    }
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -488,6 +488,8 @@
     <string name="download_completed_size">Size: %1$s</string>
     <string name="download_completed_open">Open</string>
     <string name="download_completed_delete">Delete</string>
+    <string name="download_complete_series_group">%1$s (%2$d)</string>
+    <string name="download_completed_toggle_description">Toggle list of downloaded items</string>
     <!-- Download settings -->
     <string name="settings_downloads_title">Downloads</string>
     <string name="settings_downloads_allow_metered_title">Allow metered data</string>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <external-files-path name="downloads" path="Download/InkitaUpdates/" />
+    <external-files-path name="downloads" path="download/" />
     <external-files-path name="pdfs" path="Download/Inkita/pdfs/" />
     <cache-path name="logs" path="." />
 </paths>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,12 +8,14 @@ espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
+materialIconsCoreVersion = "1.7.8"
 navigationCompose = "2.9.6"
 foundationLayout = "1.9.5"
 foundation = "1.9.5"
 aboutlib_version = "13.1.0"
 
 [libraries]
+androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "materialIconsCoreVersion" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
This PR simplifies the downloads display and makes it possible to open downloads from the completed download tab.

<details>
<summary>Screenshots</summary>
<img width="1600" height="2560" alt="image" src="https://github.com/user-attachments/assets/2413ec95-bac8-4511-b31d-c7b530f081ed" />

<img width="1600" height="2560" alt="image" src="https://github.com/user-attachments/assets/c553c0a6-589c-4a61-95db-160a7e35d6ff" />
</details>

I'm open to suggestions! This was my take on simplifying the UI, especially since the previous view included a lot of internal Kavita IDs that aren't really something a user would need to see.

I also included a fix to completed downloads' Open button. Previously this was silently erroring, I replaced the previous action/intent with the same route that other places use to launch the readers.

Fixes #31 