### PR TITLE
Cache series without vols & chapters to prevent CursorWindow size crash

### DIFF
--- a/app/src/main/java/net/dom53/inkita/data/local/db/dao/SeriesDetailV2Dao.kt
+++ b/app/src/main/java/net/dom53/inkita/data/local/db/dao/SeriesDetailV2Dao.kt
@@ -49,11 +49,17 @@ interface SeriesDetailV2Dao {
     @Query("SELECT COUNT(*) FROM cached_series_volume_refs_v2")
     suspend fun getSeriesVolumeRefsCount(): Int
 
+    @Query("SELECT * FROM cached_volumes_v2 WHERE seriesId = :seriesId")
+    suspend fun getSeriesVolumes(seriesId: Int): List<CachedVolumeV2Entity>?
+
     @Query("SELECT COUNT(*) FROM cached_chapters_v2")
     suspend fun getChaptersCount(): Int
 
     @Query("SELECT COUNT(*) FROM cached_volume_chapter_refs_v2")
     suspend fun getVolumeChapterRefsCount(): Int
+
+    @Query("SELECT * FROM cached_chapters_v2 WHERE volumeId = :volumeId")
+    suspend fun getSeriesVolumeChapters(volumeId: Int): List<CachedChapterV2Entity>?
 
     @Query("DELETE FROM cached_series_detail_v2")
     suspend fun clearSeriesDetails()


### PR DESCRIPTION
Volumes and chapters are now cached to their own tables when a series is cached, which slims down the `detailJson` column in table `cached_series_detail_v2`. Fixes #34.